### PR TITLE
Add the Data Visualizer module from UgandaEMR

### DIFF
--- a/distro/configs/openmrs/frontend_assembly/reference-application-spa-assemble-config.json
+++ b/distro/configs/openmrs/frontend_assembly/reference-application-spa-assemble-config.json
@@ -1,6 +1,7 @@
 {
   "coreVersion": "latest",
   "frontendModules": {
+    "@ugandaemr/esm-data-visualizer-app": "latest",
     "@openmrs/esm-cohort-builder-app": "latest",
     "@openmrs/esm-home-app": "latest",
     "@openmrs/esm-system-admin-app": "latest",


### PR DESCRIPTION
Added the module as the install name module is displayed here: 
https://www.npmjs.com/package/@ugandaemr/esm-data-visualizer-app
`@ugandaemr/esm-data-visualizer-app`
![image](https://github.com/user-attachments/assets/723ad510-6b2f-48ae-a145-b134ef1d7369)

Then the data visualizer should appear on the front-end right after that like on the image below.
![image](https://github.com/user-attachments/assets/1d94e464-8093-4670-96ad-8ee232c0f0fc)
