### PR TITLE
Add nginx proxy settings for Odoo and Keycloak

### DIFF
--- a/countries/burundi/pom.xml
+++ b/countries/burundi/pom.xml
@@ -130,6 +130,25 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>Copy proxy configuration</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}/run/docker/proxy</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>../../scripts</directory>
+                  <includes>
+                    <include>default.conf.template</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -153,6 +153,25 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>Copy proxy configuration</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}/run/docker/proxy</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>../scripts</directory>
+                  <includes>
+                    <include>default.conf.template</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/scripts/default.conf.template
+++ b/scripts/default.conf.template
@@ -1,0 +1,61 @@
+server {
+    listen 80;
+    server_name odoo.uvl-emr.madiro.org;
+
+    # Increase proxy buffer size
+    proxy_buffers 16 64k;
+    proxy_buffer_size 128k;
+    # Force timeouts if the openmrs:8080 dies
+    proxy_next_upstream error timeout invalid_header http_500 http_502 http_503;
+    # Enable data compression
+    gzip on;
+    gzip_min_length 1100;
+    gzip_buffers 4 32k;
+    gzip_types text/plain text/xml text/css text/less application/x-javascript application/xml application/json application/javascript;
+    gzip_vary on;
+
+    # Proxy header and settings
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+
+
+    # Cache static data
+    location ~* /web/static/ {
+        proxy_cache_valid 200 60m;
+        proxy_buffering on;
+        expires 864000;
+        set $odoo odoo:8069;
+        proxy_pass http://$odoo;
+    }
+
+    location / {
+
+        set $odoo odoo:8069;
+        proxy_pass http://$odoo;
+        # The following makes the timeout broader
+        proxy_read_timeout 30000;
+        proxy_redirect off;
+    }
+
+    location /longpolling {
+        set $odoo odoo:8072;
+        proxy_pass http://$odoo;
+    }
+}
+
+server {
+    listen 80;
+    server_name auth.uvl-emr.madiro.org;
+
+    location / {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forward-Proto http;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        set $keycloak keycloak:8080;
+        proxy_pass http://$keycloak;
+    }
+}
+

--- a/sites/mugamba/pom.xml
+++ b/sites/mugamba/pom.xml
@@ -132,6 +132,25 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>Copy proxy configuration</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}/run/docker/proxy</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>../../scripts</directory>
+                  <includes>
+                    <include>default.conf.template</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket/issue number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests. If there is no automated tests, I tested this PR on my localhost.
- [x] I included a screenshot or video of the change. This will help a lot the reviewers to test your changes and accelerate the approval. 

## Summary
This PR adds the proxy for the following services:
1. Odoo, runs on port 8069
2. Keycloak, runs on port 8084

## Screenshots or video
Testing pending

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
