### PR TITLE
Add Odoo configuration for enabling longpolling in Odoo

### DIFF
--- a/sites/mugamba/configs/odoo/config/odoo.conf
+++ b/sites/mugamba/configs/odoo/config/odoo.conf
@@ -1,0 +1,20 @@
+[options]
+addons_path = /mnt/extra-addons,/opt/odoo/addons
+data_dir = /var/lib/odoo
+initializer_checksums_path = /mnt/checksums
+initializer_data_files_paths = ${INITIALIZER_DATA_FILES_PATH}
+initializer_config_file_path = ${INITIALIZER_CONFIG_FILE_PATH}
+db_name = odoo
+without_demo = all
+proxy_mode = True
+admin_passwd = ${MASTER_PASSWORD}
+list_db = False
+test_enable = False
+test_file = False
+limit_time_real = 500
+
+# Longpolling configuration
+longpolling_port = 8072
+gevent_port = 8072
+workers = 2
+max_cron_threads = 1


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket/issue number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests. If there is no automated tests, I tested this PR on my localhost.
- [ ] I included a screenshot or video of the change. This will help a lot the reviewers to test your changes and accelerate the approval. 

## Summary
This PR adds configuration to enable longpolling service at port 8072, which wasn't running, and which also resulted in a `502` error on Nginx.

## Screenshots or video
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
