### PR TITLE
(fix) Address should not be shown on the patient sticker

### DIFF
--- a/sites/mugamba/configs/openmrs/initializer_config/jsonkeyvalues/patientIdPreportConfig.json
+++ b/sites/mugamba/configs/openmrs/initializer_config/jsonkeyvalues/patientIdPreportConfig.json
@@ -4,7 +4,7 @@
   "report.patientIdSticker.fields.dob": "true",
   "report.patientIdSticker.fields.age": "true",
   "report.patientIdSticker.fields.gender": "true",
-  "report.patientIdSticker.fields.fulladdress": "true",
+  "report.patientIdSticker.fields.fulladdress": "false",
   "report.patientIdSticker.stylesheet": "msfStickerFopStylesheet.xsl",
   "report.patientIdSticker.logourl": "https://raw.githubusercontent.com/MadiroGlobalHealth/UVL-EMR/main/distro/configs/openmrs/frontend_config/logo.png",
   "report.patientIdSticker.pages": "3",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket/issue number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests. If there is no automated tests, I tested this PR on my localhost.
- [ ] I included a screenshot or video of the change. This will help a lot the reviewers to test your changes and accelerate the approval. 

## Summary
The address for patients are showing up in their patient stickers, which is pushing details like gender, dob out of view.

## Screenshots or video
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
