### PR TITLE
Add remaining external reference links to Mugamba navigation menu

### DIFF
--- a/sites/mugamba/configs/openmrs/frontend_config/uvl-mugamba-frontend-config.json
+++ b/sites/mugamba/configs/openmrs/frontend_config/uvl-mugamba-frontend-config.json
@@ -74,6 +74,22 @@
       {
         "title": "Pharmacy, Billing & Inventory",
         "redirect": "${ODOO_PUBLIC_URL}"
+      },
+      {
+        "title": "Laboratory",
+        "redirect": "${SENAITE_PUBLIC_URL}"
+      },
+      {
+        "title": "PACS",
+        "redirect": "${ORTHANC_PUBLIC_URL}"
+      },
+      {
+        "title": "Reporting & Analytics",
+        "redirect": "${SUPERSET_PUBLIC_URL}"
+      },
+      {
+        "title": "Account Management",
+        "redirect": "${KEYCLOAK_URL}/realms/ozone/account/#/"
       }
     ],
     "extensionSlots": {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket/issue number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests. If there is no automated tests, I tested this PR on my localhost.
- [ ] I included a screenshot or video of the change. This will help a lot the reviewers to test your changes and accelerate the approval. 

## Summary
<!-- Please describe what problems your PR addresses. -->

Adds the four remaining `externalRefLinks` to the Mugamba OpenMRS frontend config so the primary navigation menu exposes all external system links, not just Pharmacy/Billing/Inventory.

## Screenshots or video
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
